### PR TITLE
Solve Issue #2 No structure inside fixture not back to default vfs structure

### DIFF
--- a/VirtualFilesystemTrait.php
+++ b/VirtualFilesystemTrait.php
@@ -17,7 +17,7 @@ trait VirtualFilesystemTrait {
 			$this->loadConfig();
 		}
 
-		if ( array_key_exists( 'structure', $this->config ) ) {
+		if ( isset( $this->config['structure'] ) && !empty( $this->config['structure'] )  ) {
 			return;
 		}
 

--- a/VirtualFilesystemTrait.php
+++ b/VirtualFilesystemTrait.php
@@ -17,7 +17,7 @@ trait VirtualFilesystemTrait {
 			$this->loadConfig();
 		}
 
-		if ( isset( $this->config['structure'] ) && !empty( $this->config['structure'] )  ) {
+		if ( ! empty( $this->config['structure'] ) ) {
 			return;
 		}
 


### PR DESCRIPTION
- [x] Add condition to check if `structure` value is not empty.

- [x] Use `isset` instead of `array_key_exists` for performance optimiziation