### PR TITLE
Update require wp-media/phpunit to ^1.1.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"brain/monkey": "^2.0",
 		"mikey179/vfsstream": "^1.6",
 		"phpunit/phpunit": "^5.7 || ^7",
-		"wp-media/phpunit": "dev-master"
+		"wp-media/phpunit": "^1.1.6"
 	},
 	"autoload": {
 		"psr-4": { "WP_Rocket\\Tests\\": "." }


### PR DESCRIPTION
This is to update the `wp-media/phpunit` requirement to a stable version in order to satisfy it's use in the new rocket modules at a stable release level.

This change will also need to be tagged as a release version and updated to packageist.